### PR TITLE
Rewrite all routes to index.html

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,12 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
     ]
   }
 }


### PR DESCRIPTION
Currently, if you refresh whilst on a page it gives you a 404 and if you visit a page directly via a URL (which isn't the base URL) it gives you a 404 due to how React works. This change tells Firebase that we are using a SPA.