### PR TITLE
Fix category selection

### DIFF
--- a/src/components/pages/Resources.js
+++ b/src/components/pages/Resources.js
@@ -140,7 +140,7 @@ class Resources extends Component {
                             <select id="filter-category" className="uk-select" onChange={this.filterResources} value={this.state.filterResources}>
                                 <option value="Show All" key="all">Show All</option>
                                 {config["resource-categories"].map((category) => (
-                                    <option value={category} key={category}>{category}</option>
+                                    <option value={category.toLowerCase()} key={category}>{category}</option>
                                 ))}
                             </select>
                         </label>


### PR DESCRIPTION
# Fix category selection
## Summary
As we can see [here](https://github.com/codesupport/website-frontend/blob/develop/src/config.js#L1) the categories start with an uppercase character. This is causing an issue when pre-filtering the categories using a GET parameter. This is due to the GET parameter being lowercase, which therefore means the categories do not match, which ultimately means it's not being selected in the dropdown list. This PR fixes this by making the value of the selection box lowercase.